### PR TITLE
Feature/telescope hidden and gitignore files

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ cd dotfiles
 > ```bash
 > mv ~/.zshrc ~/.zshrc.bak
 > mv ~/.config/nvim ~/.config/nvim.bak
+> mv ~/.tmux.conf ~/.tmux.conf.bak
 > ```
 
 ## 構成
@@ -24,3 +25,4 @@ cd dotfiles
 |---|---|
 | zsh | `~/.zshrc` |
 | nvim | `~/.config/nvim/` |
+| tmux | `~/.tmux.conf` |

--- a/nvim/.config/nvim/lua/plugins/telescope.lua
+++ b/nvim/.config/nvim/lua/plugins/telescope.lua
@@ -14,6 +14,14 @@ return {
   },
   config = function()
     require('telescope').setup {
+      pickers = {
+        find_files = {
+          hidden = true,
+        },
+        live_grep = {
+          additional_args = { '--hidden' },
+        },
+      },
       extensions = {
         ['ui-select'] = { require('telescope.themes').get_dropdown() },
       },

--- a/nvim/.config/nvim/lua/plugins/telescope.lua
+++ b/nvim/.config/nvim/lua/plugins/telescope.lua
@@ -17,9 +17,10 @@ return {
       pickers = {
         find_files = {
           hidden = true,
+          no_ignore = true,
         },
         live_grep = {
-          additional_args = { '--hidden' },
+          additional_args = { '--hidden', '--no-ignore' },
         },
       },
       extensions = {


### PR DESCRIPTION
## Summary
- Telescope の `find_files` / `live_grep` で隠しファイルとgitignoreで無視されているファイルを検索対象に追加
- README に tmux の構成情報・バックアップ手順を追記

## Changes
### feat: Telescope 隠しファイル検索対応

`nvim/.config/nvim/lua/plugins/telescope.lua` の `telescope.setup` に `pickers` 設定を追加し、`<leader>sf`（find_files）および `<leader>sg`（live_grep）で `.env` や `.zshrc`
  などの隠しファイルおよび .gitignore で除外されているファイルが検索結果に表示されるようにした。

### docs: README tmux 追記

構成テーブルに `tmux → ~/.tmux.conf` を追加し、セットアップ時のバックアップ手順に `~/.tmux.conf.bak` を追記した。