### PR TITLE
feat: add Gemini popup and refactor tmux popup logic

### DIFF
--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -69,12 +69,12 @@ bind-key -n 'C-l' if-shell "$is_vim" 'send-keys C-l'  'select-pane -R'
 bind -r g display-popup -d '#{pane_current_path}' -w90% -h90% -E lazygit
 
 
-# --- Claude Code ポップアップ ---
-# popup サイズ(90%)から実際の列数・行数を計算して new-session に渡すことで、
-# Ink (Claude Code の描画ライブラリ) のカーソル計算と実際の描画領域を一致させる。
-# これにより、ヒストリーが積み重なった際の「上の行が削除される/ジャンプする」問題を防ぐ。
-bind -r a run-shell '\
-  SESSION="claude-$(echo #{pane_current_path} | md5sum | cut -c1-8)"; \
+# --- セッション維持型ポップアップ ---
+# ポップアップを閉じても実行状態（セッション）を保持するためのロジック。
+# ポップアップのサイズ(90%)に合わせてセッションのウィンドウサイズを動的に計算・変更することで、
+# ツール側のカーソル位置計算と実際の描画領域を一致させ、表示崩れやヒストリーの跳ね返りを防ぐ。
+POPUP_WITH_SESSION=' \
+  SESSION="${AGENT_NAME}-$(echo #{pane_current_path} | md5sum | cut -c1-8)"; \
   POPUP_W=$(( #{client_width} * 90 / 100 )); \
   POPUP_H=$(( #{client_height} * 90 / 100 )); \
   if tmux has-session -t "$SESSION" 2>/dev/null; then \
@@ -83,26 +83,12 @@ bind -r a run-shell '\
     tmux new-session -d -s "$SESSION" \
       -c "#{pane_current_path}" \
       -x "$POPUP_W" -y "$POPUP_H" \
-      "claude"; \
+      "$AGENT_CMD"; \
     tmux set-option -t "$SESSION" window-size latest; \
   fi; \
   tmux display-popup -w90% -h90% -E "tmux attach-session -t $SESSION"'
 
-# --- Codex CLI ポップアップ ---
-# popup サイズ(90%)から実際の列数・行数を計算して new-session に渡すことで、
-# Ink (Claude Code の描画ライブラリ) のカーソル計算と実際の描画領域を一致させる。
-# これにより、ヒストリーが積み重なった際の「上の行が削除される/ジャンプする」問題を防ぐ。
-bind -r o run-shell '\
-  SESSION="codex-$(echo #{pane_current_path} | md5sum | cut -c1-8)"; \
-  POPUP_W=$(( #{client_width} * 90 / 100 )); \
-  POPUP_H=$(( #{client_height} * 90 / 100 )); \
-  if tmux has-session -t "$SESSION" 2>/dev/null; then \
-    tmux resize-window -t "$SESSION" -x "$POPUP_W" -y "$POPUP_H"; \
-  else \
-    tmux new-session -d -s "$SESSION" \
-      -c "#{pane_current_path}" \
-      -x "$POPUP_W" -y "$POPUP_H" \
-      "codex"; \
-    tmux set-option -t "$SESSION" window-size latest; \
-  fi; \
-  tmux display-popup -w90% -h90% -E "tmux attach-session -t $SESSION"'
+# 各種ツールをセッション維持型ポップアップで起動
+bind -r a run-shell "AGENT_NAME=claude AGENT_CMD=claude $POPUP_WITH_SESSION"
+bind -r o run-shell "AGENT_NAME=codex  AGENT_CMD=codex  $POPUP_WITH_SESSION"
+bind -r G run-shell "AGENT_NAME=gemini AGENT_CMD=gemini $POPUP_WITH_SESSION"

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -74,7 +74,7 @@ bind -r g display-popup -d '#{pane_current_path}' -w90% -h90% -E lazygit
 # ポップアップのサイズ(90%)に合わせてセッションのウィンドウサイズを動的に計算・変更することで、
 # ツール側のカーソル位置計算と実際の描画領域を一致させ、表示崩れやヒストリーの跳ね返りを防ぐ。
 POPUP_WITH_SESSION=' \
-  SESSION="${AGENT_NAME}-$(echo #{pane_current_path} | md5sum | cut -c1-8)"; \
+  SESSION="${POPUP_NAME}-$(echo #{pane_current_path} | md5sum | cut -c1-8)"; \
   POPUP_W=$(( #{client_width} * 90 / 100 )); \
   POPUP_H=$(( #{client_height} * 90 / 100 )); \
   if tmux has-session -t "$SESSION" 2>/dev/null; then \
@@ -83,12 +83,12 @@ POPUP_WITH_SESSION=' \
     tmux new-session -d -s "$SESSION" \
       -c "#{pane_current_path}" \
       -x "$POPUP_W" -y "$POPUP_H" \
-      "$AGENT_CMD"; \
+      "$POPUP_CMD"; \
     tmux set-option -t "$SESSION" window-size latest; \
   fi; \
   tmux display-popup -w90% -h90% -E "tmux attach-session -t $SESSION"'
 
 # 各種ツールをセッション維持型ポップアップで起動
-bind -r a run-shell "AGENT_NAME=claude AGENT_CMD=claude $POPUP_WITH_SESSION"
-bind -r o run-shell "AGENT_NAME=codex  AGENT_CMD=codex  $POPUP_WITH_SESSION"
-bind -r G run-shell "AGENT_NAME=gemini AGENT_CMD=gemini $POPUP_WITH_SESSION"
+bind -r a run-shell "POPUP_NAME=claude POPUP_CMD=claude $POPUP_WITH_SESSION"
+bind -r o run-shell "POPUP_NAME=codex  POPUP_CMD=codex  $POPUP_WITH_SESSION"
+bind -r G run-shell "POPUP_NAME=gemini POPUP_CMD=gemini $POPUP_WITH_SESSION"


### PR DESCRIPTION
- Add keybinding for Gemini CLI popup (<prefix>G)
- Refactor session-persistent popup logic into a reusable variable (`POPUP_WITH_SESSION`)
- Update Claude and Codex keybindings to use the refactored logic
- Rename `AGENT_NAME`/`AGENT_CMD` to `POPUP_NAME`/`POPUP_CMD` for non-AI use cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)