### PR TITLE
feat: macOS セットアップスクリプトと Brewfile を追加

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,14 @@
+# Core: dotfile 管理
+brew "stow"
+
+# Editor / Terminal multiplexer
+brew "neovim"
+brew "tmux"
+
+# 言語ランタイム / バージョン管理
+brew "openjdk@25"
+brew "nodebrew"
+
+# Git ツールチェーン
+brew "git"
+brew "gh"

--- a/Brewfile
+++ b/Brewfile
@@ -1,14 +1,47 @@
-# Core: dotfile 管理
+# --- Core: dotfile 管理 ---
 brew "stow"
 
-# Editor / Terminal multiplexer
+# --- Editor / Terminal multiplexer ---
 brew "neovim"
 brew "tmux"
 
-# 言語ランタイム / バージョン管理
+# --- 言語ランタイム / バージョン管理 ---
 brew "openjdk@25"
 brew "nodebrew"
 
-# Git ツールチェーン
+# --- Git ツールチェーン ---
 brew "git"
 brew "gh"
+brew "lazygit"          # tmux <prefix>g
+
+# --- AI CLI（tmux ポップアップから呼ぶ）---
+brew "gemini-cli"       # tmux <prefix>G
+
+# --- nvim プラグインビルド依存 ---
+brew "make"
+brew "cmake"
+brew "gcc"
+brew "tree-sitter"
+brew "tree-sitter-cli"
+brew "ripgrep"          # telescope live_grep
+
+# --- Mason がダウンロードに使う ---
+brew "curl"
+brew "wget"
+brew "unzip"
+
+# --- Python ツール ---
+brew "uv"
+brew "ruff"
+brew "basedpyright"
+
+# --- 開発便利ツール ---
+brew "fzf"
+brew "jq"
+brew "tree"
+brew "shellcheck"       # Claude Code の自動フォーマットフックが使用
+
+# --- macOS 専用（cask は Homebrew 上で macOS 限定。Linux では別途 apt 等で導入する） ---
+cask "docker-desktop"                 # tmux でアプリ完結（旧 cask "docker" は非推奨）
+cask "claude-code"                    # tmux <prefix>a
+cask "font-jetbrains-mono-nerd-font"  # 接続元ターミナルのフォント（Ubuntu Server へも反映）

--- a/README.md
+++ b/README.md
@@ -4,11 +4,23 @@ GNU Stow で管理する個人の dotfiles リポジトリ。
 
 ## セットアップ
 
-```bash
-# 前提: GNU Stow がインストール済み (例: brew install stow)
+### 新品 Mac（Homebrew 未導入）
 
+```bash
 git clone git@github.com:mugi-02050x/dotfiles.git
 cd dotfiles
+./setup-mac.sh
+```
+
+Xcode Command Line Tools と Homebrew が未導入の場合は自動でインストールします。
+その後 `Brewfile` に記載されたパッケージを一括導入し、symlink を配置します。
+
+### 既存環境（Homebrew 導入済み）
+
+```bash
+git clone git@github.com:mugi-02050x/dotfiles.git
+cd dotfiles
+brew bundle
 ./install.sh
 ```
 
@@ -26,3 +38,12 @@ cd dotfiles
 | zsh | `~/.zshrc` |
 | nvim | `~/.config/nvim/` |
 | tmux | `~/.tmux.conf` |
+
+### Brewfile へのパッケージ追加
+
+`Brewfile` を編集して `brew bundle` を再実行すると差分のみインストールされます。
+
+```bash
+echo 'brew "ripgrep"' >> Brewfile
+brew bundle
+```

--- a/setup-mac.sh
+++ b/setup-mac.sh
@@ -44,10 +44,13 @@ if ! command -v node &>/dev/null; then
   export PATH="$HOME/.nodebrew/current/bin:$PATH"
 fi
 
-# グローバル npm パッケージ（tmux <prefix>o で呼ぶ codex など）
-if command -v npm &>/dev/null; then
+# グローバル npm パッケージ（追加はこの配列に行を増やす）
+NPM_GLOBALS=(
+  "@openai/codex"   # tmux <prefix>o
+)
+if command -v npm &>/dev/null && [[ ${#NPM_GLOBALS[@]} -gt 0 ]]; then
   echo "Installing global npm packages..."
-  npm install -g @openai/codex
+  npm install -g "${NPM_GLOBALS[@]}"
 fi
 
 # symlink 配置

--- a/setup-mac.sh
+++ b/setup-mac.sh
@@ -31,6 +31,25 @@ fi
 echo "Installing packages from Brewfile..."
 brew bundle --file="$DOTFILES_DIR/Brewfile"
 
+# Node.js（nodebrew で最新版を導入）
+if ! command -v node &>/dev/null; then
+  echo "Installing Node.js via nodebrew..."
+  nodebrew setup 2>/dev/null || true
+  nodebrew install-binary latest
+  _latest_node="$(find "$HOME/.nodebrew/node" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; 2>/dev/null | sort -V | tail -1)"
+  if [[ -n "${_latest_node:-}" ]]; then
+    nodebrew use "$_latest_node"
+  fi
+  unset _latest_node
+  export PATH="$HOME/.nodebrew/current/bin:$PATH"
+fi
+
+# グローバル npm パッケージ（tmux <prefix>o で呼ぶ codex など）
+if command -v npm &>/dev/null; then
+  echo "Installing global npm packages..."
+  npm install -g @openai/codex
+fi
+
 # symlink 配置
 echo "Linking dotfiles..."
 "$DOTFILES_DIR/install.sh"

--- a/setup-mac.sh
+++ b/setup-mac.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "Error: this script is for macOS only" >&2
+  exit 1
+fi
+
+DOTFILES_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Xcode Command Line Tools
+if ! xcode-select -p &>/dev/null; then
+  echo "Installing Xcode Command Line Tools..."
+  xcode-select --install
+  echo "Complete the GUI dialog, then press Enter to continue..."
+  read -r
+fi
+
+# Homebrew
+if ! command -v brew &>/dev/null; then
+  echo "Installing Homebrew..."
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  if [[ -x /opt/homebrew/bin/brew ]]; then
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+  elif [[ -x /usr/local/bin/brew ]]; then
+    eval "$(/usr/local/bin/brew shellenv)"
+  fi
+fi
+
+# パッケージ一括導入
+echo "Installing packages from Brewfile..."
+brew bundle --file="$DOTFILES_DIR/Brewfile"
+
+# symlink 配置
+echo "Linking dotfiles..."
+"$DOTFILES_DIR/install.sh"
+
+echo "Done. Restart your shell or run: exec zsh -l"

--- a/setup-mac.sh
+++ b/setup-mac.sh
@@ -46,7 +46,8 @@ fi
 
 # グローバル npm パッケージ（追加はこの配列に行を増やす）
 NPM_GLOBALS=(
-  "@openai/codex"   # tmux <prefix>o
+  "@openai/codex"      # tmux <prefix>o
+  "obsidian-headless"  # Obsidian 自動化 CLI
 )
 if command -v npm &>/dev/null && [[ ${#NPM_GLOBALS[@]} -gt 0 ]]; then
   echo "Installing global npm packages..."

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -20,10 +20,12 @@ fi
 [[ -d /nix/var/nix/profiles/default ]] && _pm_prefixes+=("/nix/var/nix/profiles/default")
 
 # --- PATH 構築 ---
-for _p in "${_pm_prefixes[@]}"; do
-  [[ -d "$_p/bin" ]]  && PATH="$_p/bin:$PATH"
-  [[ -d "$_p/sbin" ]] && PATH="$_p/sbin:$PATH"
-done
+# 「先頭追加」方式: 低優先のものから順に追加する（後から追加したものほど PATH 先頭=高優先になる）
+# 最終的な優先順位（高い順）:
+#   JAVA_HOME → nodebrew → Homebrew(pm_prefixes) → ~/.local/bin → /usr/local → VMware → 元の PATH
+
+# VMware Fusion の CLI ツール（vmrun、ovftool など）— 使用頻度が低く名前衝突もないので最下位
+[[ -d "/Applications/VMware Fusion.app/Contents/Public" ]]         && PATH="/Applications/VMware Fusion.app/Contents/Public:$PATH"
 
 # FHS 標準パス（pm_prefix とは独立、手動インストール先）
 [[ -d /usr/local/bin ]]  && PATH="/usr/local/bin:$PATH"
@@ -31,11 +33,17 @@ done
 
 # ユーザー単位ローカルバイナリ（pipx、pip --user、cargo install など / XDG 慣習）
 [[ -d "$HOME/.local/bin" ]]                                        && PATH="$HOME/.local/bin:$PATH"
+
+# パッケージマネージャ（Homebrew 等）— 同名コマンドがあれば手動インストールより優先したい
+for _p in "${_pm_prefixes[@]}"; do
+  [[ -d "$_p/bin" ]]  && PATH="$_p/bin:$PATH"
+  [[ -d "$_p/sbin" ]] && PATH="$_p/sbin:$PATH"
+done
+
 # nodebrew が選択中の Node.js バージョン（node, npm, グローバルインストール CLI）
+# Homebrew 版 node より優先したいので Homebrew より後に追加
 [[ -d "$HOME/.nodebrew/current/bin" ]]                             && PATH="$HOME/.nodebrew/current/bin:$PATH"
 [[ -d "$HOME/.nodebrew/current/sbin" ]]                            && PATH="$HOME/.nodebrew/current/sbin:$PATH"
-# VMware Fusion の CLI ツール（vmrun、ovftool など）
-[[ -d "/Applications/VMware Fusion.app/Contents/Public" ]]         && PATH="/Applications/VMware Fusion.app/Contents/Public:$PATH"
 
 export PATH
 

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -22,10 +22,7 @@ fi
 # --- PATH 構築 ---
 # 「先頭追加」方式: 低優先のものから順に追加する（後から追加したものほど PATH 先頭=高優先になる）
 # 最終的な優先順位（高い順）:
-#   JAVA_HOME → nodebrew → Homebrew(pm_prefixes) → ~/.local/bin → /usr/local → VMware → 元の PATH
-
-# VMware Fusion の CLI ツール（vmrun、ovftool など）— 使用頻度が低く名前衝突もないので最下位
-[[ -d "/Applications/VMware Fusion.app/Contents/Public" ]]         && PATH="/Applications/VMware Fusion.app/Contents/Public:$PATH"
+#   JAVA_HOME → nodebrew → Homebrew(pm_prefixes) → ~/.local/bin → /usr/local → 元の PATH
 
 # FHS 標準パス（pm_prefix とは独立、手動インストール先）
 [[ -d /usr/local/bin ]]  && PATH="/usr/local/bin:$PATH"


### PR DESCRIPTION
## Summary

新品 Mac から動作環境を 1 コマンドで再現できる `setup-mac.sh` と `Brewfile` を追加。

- `setup-mac.sh`: Xcode CLT / Homebrew 未導入なら自動インストール → `brew bundle` → 既存の `install.sh` を呼んで stow
- `Brewfile`: リポジトリ設定（`.zshrc`, `.tmux.conf`, nvim 設定）が依存する全パッケージを宣言
- `README.md`: 新フローを反映、Brewfile への追加方法を追記

Closes #9

## Brewfile に含めたパッケージの根拠

| カテゴリ | パッケージ | 必要な理由 |
|---|---|---|
| Core | stow | `install.sh` が呼ぶ |
| Editor | neovim | `.zshrc` の vi/vim alias 先 |
| Multiplexer | tmux | `tmux/.tmux.conf` |
| Runtime | openjdk@25 | `.zshrc` の JAVA_HOME ターゲット |
| Runtime | nodebrew | `.zshrc` で PATH 通している Node 管理 |
| Git | git, gh, lazygit | lazygit は `.tmux.conf` の `<prefix>g` |
| AI CLI | gemini-cli | `.tmux.conf` の `<prefix>G` |
| nvim ビルド | make, cmake, gcc | telescope-fzf-native の `build = 'make'` 等 |
| nvim 検索 | ripgrep | telescope `live_grep` |
| nvim パーサ | tree-sitter, tree-sitter-cli | nvim-treesitter |
| Mason 取得 | curl, wget, unzip | mason-tool-installer |
| Python | uv, ruff, basedpyright | LSP / フォーマッタ |
| 便利 | fzf, jq, tree, shellcheck | 標準的開発ツール |
| cask | docker-desktop | Docker（旧 cask "docker" は非推奨） |
| cask | claude-code | `.tmux.conf` の `<prefix>a` |
| cask | font-jetbrains-mono-nerd-font | nvim アイコン表示 |

## 含めなかったもの

- openjdk@11/17/21（プロジェクト依存のため個別追加に委ねる）
- vim, screen, socat（未使用）
- yarn, luarocks（確認時に未選択）
- tap "homebrew/cask-versions"（2024 年に deprecated）
- codex（brew パッケージではない、別経路で管理）

## Test plan

- [x] `bash -n setup-mac.sh` で構文エラーなし
- [x] `shellcheck setup-mac.sh` で警告なし
- [x] `brew bundle check --file=Brewfile` が DSL レベルで構文 OK
- [ ] 新品 Mac での完全実行（実機なし、手動確認スコープ外）

🤖 Generated with [Claude Code](https://claude.com/claude-code)