### PR TITLE
Support SSH client clipboard copy via OSC 52

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,6 @@ echo "copy me" | clip
 clip "copy me"
 ```
 
-tmuxのコピーモードでは `y` / `Enter` で `clip` に渡します。NeovimはSSH接続中のみ `"+y` や通常のyankを `clip` 経由にします。
+tmuxのコピーモードでは `y` / `Enter` で `clip` に渡します。NeovimはSSH接続中のみ通常のyankを内部レジスタに残したまま `clip` へミラーし、`"+y` も `clip` 経由にします。
 
 Windows TerminalなどOSC 52対応のSSHクライアントで動作します。AndroidのSSHクライアントはOSC 52対応状況に依存します。

--- a/README.md
+++ b/README.md
@@ -26,3 +26,17 @@ cd dotfiles
 | zsh | `~/.zshrc` |
 | nvim | `~/.config/nvim/` |
 | tmux | `~/.tmux.conf` |
+| bin | `~/.local/bin/` |
+
+## SSH元クリップボードへのコピー
+
+SSH接続中は `clip` コマンドがOSC 52を使ってSSHクライアント側のクリップボードへコピーします。
+
+```bash
+echo "copy me" | clip
+clip "copy me"
+```
+
+tmuxのコピーモードでは `y` / `Enter` で `clip` に渡します。NeovimはSSH接続中のみ `"+y` や通常のyankを `clip` 経由にします。
+
+Windows TerminalなどOSC 52対応のSSHクライアントで動作します。AndroidのSSHクライアントはOSC 52対応状況に依存します。

--- a/bin/.local/bin/clip
+++ b/bin/.local/bin/clip
@@ -4,12 +4,14 @@ set -eu
 tmp="$(mktemp "${TMPDIR:-/tmp}/clip.XXXXXX")"
 trap 'rm -f "$tmp"' EXIT HUP INT TERM
 
+# 引数があれば引数を、なければパイプや標準入力の内容を受け取る。
 if [ "$#" -gt 0 ]; then
   printf '%s' "$*" >"$tmp"
 else
   cat >"$tmp"
 fi
 
+# ローカルのmacOS上では通常のpbcopyを使う。
 if [ -z "${SSH_CONNECTION:-}${SSH_TTY:-}" ] && command -v pbcopy >/dev/null 2>&1; then
   pbcopy <"$tmp"
   exit 0
@@ -18,15 +20,18 @@ fi
 output=
 tmux_passthrough=0
 
+# tmux内では、接続元クライアントのTTYへOSC 52を直接送る。
 if [ -n "${TMUX:-}" ] && command -v tmux >/dev/null 2>&1; then
   client_tty="$(tmux display-message -p '#{client_tty}' 2>/dev/null || true)"
   if [ -n "$client_tty" ] && [ -w "$client_tty" ]; then
     output="$client_tty"
   else
+    # クライアントTTYが使えない場合はtmux passthroughに切り替える。
     tmux_passthrough=1
   fi
 fi
 
+# tmux外では標準出力、または制御端末へシーケンスを送る。
 if [ -z "$output" ] && [ -t 1 ]; then
   output=-
 elif [ -z "$output" ] && [ -w /dev/tty ]; then
@@ -40,12 +45,14 @@ fi
 
 encoded="$(base64 <"$tmp" | tr -d '\n')"
 
+# OSC 52はクリップボード内容をbase64で運ぶ。tmux passthrough時はラップする。
 if [ "$tmux_passthrough" -eq 1 ]; then
   sequence="$(printf '\033Ptmux;\033\033]52;c;%s\a\033\\' "$encoded")"
 else
   sequence="$(printf '\033]52;c;%s\a' "$encoded")"
 fi
 
+# 改行を追加せずにエスケープシーケンスを出力する。
 if [ "$output" = - ]; then
   printf '%s' "$sequence"
 else

--- a/bin/.local/bin/clip
+++ b/bin/.local/bin/clip
@@ -1,0 +1,53 @@
+#!/bin/sh
+set -eu
+
+tmp="$(mktemp "${TMPDIR:-/tmp}/clip.XXXXXX")"
+trap 'rm -f "$tmp"' EXIT HUP INT TERM
+
+if [ "$#" -gt 0 ]; then
+  printf '%s' "$*" >"$tmp"
+else
+  cat >"$tmp"
+fi
+
+if [ -z "${SSH_CONNECTION:-}${SSH_TTY:-}" ] && command -v pbcopy >/dev/null 2>&1; then
+  pbcopy <"$tmp"
+  exit 0
+fi
+
+output=
+tmux_passthrough=0
+
+if [ -n "${TMUX:-}" ] && command -v tmux >/dev/null 2>&1; then
+  client_tty="$(tmux display-message -p '#{client_tty}' 2>/dev/null || true)"
+  if [ -n "$client_tty" ] && [ -w "$client_tty" ]; then
+    output="$client_tty"
+  else
+    tmux_passthrough=1
+  fi
+fi
+
+if [ -z "$output" ] && [ -t 1 ]; then
+  output=-
+elif [ -z "$output" ] && [ -w /dev/tty ]; then
+  output=/dev/tty
+fi
+
+if [ -z "$output" ]; then
+  printf '%s\n' 'clip: no terminal available for OSC 52 clipboard copy' >&2
+  exit 1
+fi
+
+encoded="$(base64 <"$tmp" | tr -d '\n')"
+
+if [ "$tmux_passthrough" -eq 1 ]; then
+  sequence="$(printf '\033Ptmux;\033\033]52;c;%s\a\033\\' "$encoded")"
+else
+  sequence="$(printf '\033]52;c;%s\a' "$encoded")"
+fi
+
+if [ "$output" = - ]; then
+  printf '%s' "$sequence"
+else
+  printf '%s' "$sequence" >"$output"
+fi

--- a/bin/.local/bin/clip
+++ b/bin/.local/bin/clip
@@ -21,9 +21,23 @@ output=
 tmux_passthrough=0
 
 # tmux内では、接続元クライアントのTTYへOSC 52を直接送る。
+# popup内で別セッションにattachしている場合、client_ttyはpopupペインのTTYになるため、
+# 実SSH端末のTTYがtmux clientとして存在するならそちらを優先する。
 if [ -n "${TMUX:-}" ] && command -v tmux >/dev/null 2>&1; then
   client_tty="$(tmux display-message -p '#{client_tty}' 2>/dev/null || true)"
-  if [ -n "$client_tty" ] && [ -w "$client_tty" ]; then
+  ssh_tty_attached=0
+  if [ -n "${SSH_TTY:-}" ] && [ -w "$SSH_TTY" ]; then
+    for tty in $(tmux list-clients -F '#{client_tty}' 2>/dev/null || true); do
+      if [ "$tty" = "$SSH_TTY" ]; then
+        ssh_tty_attached=1
+        break
+      fi
+    done
+  fi
+
+  if [ "$ssh_tty_attached" -eq 1 ] && [ "$client_tty" != "$SSH_TTY" ]; then
+    output="$SSH_TTY"
+  elif [ -n "$client_tty" ] && [ -w "$client_tty" ]; then
     output="$client_tty"
   else
     # クライアントTTYが使えない場合はtmux passthroughに切り替える。

--- a/install.sh
+++ b/install.sh
@@ -7,5 +7,6 @@ cd "$DOTFILES_DIR"
 stow --target="$HOME" zsh
 stow --target="$HOME" nvim
 stow --target="$HOME" tmux
+stow --target="$HOME" bin
 
 echo "Done!"

--- a/nvim/.config/nvim/lua/config/autocmds.lua
+++ b/nvim/.config/nvim/lua/config/autocmds.lua
@@ -18,3 +18,26 @@ vim.api.nvim_create_autocmd('TextYankPost', {
   group = vim.api.nvim_create_augroup('kickstart-highlight-yank', { clear = true }),
   callback = function() vim.hl.on_yank() end,
 })
+
+vim.api.nvim_create_autocmd('TextYankPost', {
+  desc = 'Copy SSH yanks to the client clipboard',
+  group = vim.api.nvim_create_augroup('ssh-clipboard-yank', { clear = true }),
+  callback = function()
+    if not vim.g.ssh_clipboard_copy then return end
+
+    local event = vim.v.event
+    if event.operator ~= 'y' or event.regname == '+' or event.regname == '*' then return end
+
+    local lines = event.regcontents
+    if type(lines) ~= 'table' or #lines == 0 then return end
+
+    local text = table.concat(lines, '\n')
+    if event.regtype == 'V' then text = text .. '\n' end
+
+    local job = vim.fn.jobstart({ 'clip' }, { stdin = 'pipe' })
+    if job <= 0 then return end
+
+    vim.fn.chansend(job, text)
+    vim.fn.chanclose(job, 'stdin')
+  end,
+})

--- a/nvim/.config/nvim/lua/config/options.lua
+++ b/nvim/.config/nvim/lua/config/options.lua
@@ -7,6 +7,20 @@ vim.o.mouse = 'a'
 vim.o.showmode = false
 
 -- Sync clipboard between OS and Neovim.
+if (vim.env.SSH_CONNECTION or vim.env.SSH_TTY) and vim.fn.executable('clip') == 1 then
+  vim.g.clipboard = {
+    name = 'OSC 52',
+    copy = {
+      ['+'] = 'clip',
+      ['*'] = 'clip',
+    },
+    paste = {
+      ['+'] = 'cat /dev/null',
+      ['*'] = 'cat /dev/null',
+    },
+    cache_enabled = 0,
+  }
+end
 vim.schedule(function() vim.o.clipboard = 'unnamedplus' end)
 
 vim.o.breakindent = true

--- a/nvim/.config/nvim/lua/config/options.lua
+++ b/nvim/.config/nvim/lua/config/options.lua
@@ -7,7 +7,9 @@ vim.o.mouse = 'a'
 vim.o.showmode = false
 
 -- Sync clipboard between OS and Neovim.
-if (vim.env.SSH_CONNECTION or vim.env.SSH_TTY) and vim.fn.executable('clip') == 1 then
+local use_ssh_clipboard = (vim.env.SSH_CONNECTION or vim.env.SSH_TTY) and vim.fn.executable('clip') == 1
+if use_ssh_clipboard then
+  vim.g.ssh_clipboard_copy = true
   vim.g.clipboard = {
     name = 'OSC 52',
     copy = {
@@ -20,8 +22,9 @@ if (vim.env.SSH_CONNECTION or vim.env.SSH_TTY) and vim.fn.executable('clip') == 
     },
     cache_enabled = 0,
   }
+else
+  vim.schedule(function() vim.o.clipboard = 'unnamedplus' end)
 end
-vim.schedule(function() vim.o.clipboard = 'unnamedplus' end)
 
 vim.o.breakindent = true
 vim.o.undofile = true

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -30,6 +30,11 @@ set -ga terminal-features 'xterm*:extkeys'
 set -ga terminal-features 'tmux*:extkeys'
 set -g extended-keys on
 
+# SSHクライアント側のクリップボードへOSC 52でコピーできるようにする
+set -g set-clipboard on
+set -g allow-passthrough on
+set -as terminal-features ',xterm*:clipboard'
+
 # --- ペイン操作 (Vimライク) ---
 # 直感的なキーでペインを分割する (-c "#{pane_current_path}" で現在のディレクトリを引き継ぐ)
 bind | split-window -h -c "#{pane_current_path}" # 縦に分割
@@ -42,7 +47,7 @@ bind -r K resize-pane -U 5
 bind -r L resize-pane -R 5
 
 
-# --- コピーモードと macOS クリップボード連携 ---
+# --- コピーモードとクリップボード連携 ---
 # コピーモードのキーバインドをVim風(h,j,k,l等)にする
 setw -g mode-keys vi
 
@@ -51,9 +56,9 @@ bind -T copy-mode-vi v send -X begin-selection
 # 選択をキャンセルする場合は 'Esc'
 bind -T copy-mode-vi Escape send -X clear-selection
 
-# 'y' または 'Enter' でヤンク(コピー)し、macOSのクリップボード (pbcopy) に渡す
-bind -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "pbcopy"
-bind -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel "pbcopy"
+# 'y' または 'Enter' でヤンク(コピー)し、ローカル/SSHクライアント側のクリップボードに渡す
+bind -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "clip"
+bind -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel "clip"
 
 
 # --- vim-tmux-navigator 連携 ---


### PR DESCRIPTION
## Summary

- add a stowed clip command that copies to pbcopy locally and OSC 52 over SSH
- route tmux copy-mode y/Enter through clip
- configure Neovim to use clip as the SSH clipboard provider
- document SSH client clipboard usage

## Verification

- sh -n bin/.local/bin/clip
- bash -n install.sh
- luac -p nvim/.config/nvim/lua/config/options.lua
- stow --simulate --verbose --target=$HOME bin
- manually verified OSC 52 copy from SSH and tmux sessions

Closes #13