### PR TITLE
tmux: forward extended keys for SSH newline

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,27 @@ clip "copy me"
 tmuxのコピーモードでは `y` / `Enter` で `clip` に渡します。NeovimはSSH接続中のみ通常のyankを内部レジスタに残したまま `clip` へミラーし、`"+y` も `clip` 経由にします。
 
 Windows TerminalなどOSC 52対応のSSHクライアントで動作します。AndroidのSSHクライアントはOSC 52対応状況に依存します。
+
+## SSH接続時の改行入力
+
+agent系TUIの複数行入力では、通常の `Enter` は送信、`Shift+Enter` は改行として扱われることがあります。
+tmux上でも `Shift+Enter` をアプリへ渡すため、`~/.tmux.conf` では `extended-keys always` と `xterm*` / `tmux*` の `extkeys` を有効にしています。
+
+設定変更後は既存tmuxサーバーに反映してください。
+
+```bash
+tmux source-file ~/.tmux.conf
+tmux show-options -g extended-keys
+tmux show-options -g terminal-features
+```
+
+`extended-keys always` が表示されていればtmux側の設定は有効です。
+それでも `Shift+Enter` が改行にならない場合は、SSHクライアントまたは端末アプリが `Shift+Enter` を通常の `Enter` と同じコードで送っている可能性があります。
+
+切り分けにはtmuxの外と中で次を実行し、`Shift+Enter` が `^[[13;2u` のような通常の改行とは異なるシーケンスになるか確認します。
+
+```bash
+cat -v
+```
+
+`Enter` と `Shift+Enter` がどちらも単なる改行として表示される場合、このdotfiles側では区別できないため、接続元のターミナル設定やSSHクライアントを変更してください。

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -25,10 +25,12 @@ set -g base-index 1
 setw -g pane-base-index 1
 set -g renumber-windows on
 
-# Shift + Enterで送信せずに改行
+# Shift+Enterなどの修飾キー付きEnterをagent系TUIへ渡す
+# `on` はアプリ側が拡張キーを要求した場合だけ転送するため、
+# SSH/tmux越しでも複数行入力に使えるよう常時転送する。
 set -ga terminal-features 'xterm*:extkeys'
 set -ga terminal-features 'tmux*:extkeys'
-set -g extended-keys on
+set -g extended-keys always
 
 # SSHクライアント側のクリップボードへOSC 52でコピーできるようにする
 set -g set-clipboard on


### PR DESCRIPTION
## Summary
- set tmux extended-keys to always so Shift+Enter can reach agent TUIs over SSH/tmux
- document how to reload tmux settings and inspect Enter vs Shift+Enter sequences with cat -v

## Verification
- git diff --check
- tmux -L codex-issue15 -f tmux/.tmux.conf new-session -d -s codex-issue15 sleep 60
- tmux -L codex-issue15 show-options -g extended-keys
- tmux -L codex-issue15 show-options -g terminal-features

Closes #15