### PR TITLE
Improve Java DAP launch configuration

### DIFF
--- a/nvim/.config/nvim/ftplugin/java.lua
+++ b/nvim/.config/nvim/ftplugin/java.lua
@@ -111,32 +111,32 @@ config['on_attach'] = function()
   jdtls_dap.fetch_main_configs({ config_overrides = { noDebug = false } }, function(configurations)
     local dap_configurations = dap.configurations.java or {}
 
-    local function remove_main_class_configs(config)
+    local function remove_main_class_configs(main_config)
       for i = #dap_configurations, 1, -1 do
         local existing_config = dap_configurations[i]
         if
           existing_config.type == 'java'
           and existing_config.request == 'launch'
-          and existing_config.mainClass == config.mainClass
-          and existing_config.projectName == config.projectName
-          and existing_config.cwd == config.cwd
+          and existing_config.mainClass == main_config.mainClass
+          and existing_config.projectName == main_config.projectName
+          and existing_config.cwd == main_config.cwd
         then
           table.remove(dap_configurations, i)
         end
       end
     end
 
-    local function append_config(config) table.insert(dap_configurations, config) end
+    local function append_config(dap_config) table.insert(dap_configurations, dap_config) end
 
-    for _, config in ipairs(configurations) do
-      remove_main_class_configs(config)
+    for _, main_config in ipairs(configurations) do
+      remove_main_class_configs(main_config)
 
-      local debug_config = vim.deepcopy(config)
+      local debug_config = vim.deepcopy(main_config)
       debug_config.name = debug_config.name:gsub('^Launch ', 'Debug ', 1)
       debug_config.noDebug = false
       append_config(debug_config)
 
-      local run_config = vim.deepcopy(config)
+      local run_config = vim.deepcopy(main_config)
       run_config.name = run_config.name:gsub('^Launch ', 'Run ', 1)
       run_config.noDebug = true
       append_config(run_config)

--- a/nvim/.config/nvim/ftplugin/java.lua
+++ b/nvim/.config/nvim/ftplugin/java.lua
@@ -12,6 +12,7 @@ end
 
 local bufnr = vim.api.nvim_get_current_buf()
 local bufname = vim.api.nvim_buf_get_name(bufnr)
+-- JDTLS expects a real file URI; skip scratch/special Java buffers that would resolve to file://.
 if bufname == '' or vim.bo[bufnr].buftype ~= '' then return end
 
 local extendedClientCapabilities = jdtls.extendedClientCapabilities

--- a/nvim/.config/nvim/ftplugin/java.lua
+++ b/nvim/.config/nvim/ftplugin/java.lua
@@ -10,6 +10,10 @@ if not status then
   return
 end
 
+local bufnr = vim.api.nvim_get_current_buf()
+local bufname = vim.api.nvim_buf_get_name(bufnr)
+if bufname == '' or vim.bo[bufnr].buftype ~= '' then return end
+
 local extendedClientCapabilities = jdtls.extendedClientCapabilities
 
 local bundles = {}
@@ -84,7 +88,7 @@ local config = {
         },
       },
       format = {
-        eabled = true,
+        enabled = true,
       },
     },
   },
@@ -94,9 +98,18 @@ local config = {
   },
 }
 
-config['on_attach'] = function(client, bufnr)
-  jdtls.setup_dap { hotcodereplace = 'auto' }
-  require('jdtls.dap').setup_dap_main_class_configs()
+config['on_attach'] = function()
+  local dap_ok, dap = pcall(require, 'dap')
+  if dap_ok then
+    dap.defaults.fallback.terminal_win_cmd = 'botright 15new'
+    dap.defaults.fallback.focus_terminal = true
+  end
+  jdtls.setup_dap { config_overrides = {}, hotcodereplace = 'auto' }
+  require('jdtls.dap').setup_dap_main_class_configs {
+    config_overrides = {
+      noDebug = true,
+    },
+  }
 end
 
 jdtls.start_or_attach(config)

--- a/nvim/.config/nvim/ftplugin/java.lua
+++ b/nvim/.config/nvim/ftplugin/java.lua
@@ -101,16 +101,49 @@ local config = {
 
 config['on_attach'] = function()
   local dap_ok, dap = pcall(require, 'dap')
-  if dap_ok then
-    dap.defaults.fallback.terminal_win_cmd = 'botright 15new'
-    dap.defaults.fallback.focus_terminal = true
-  end
+  if not dap_ok then return end
+
   jdtls.setup_dap { config_overrides = {}, hotcodereplace = 'auto' }
-  require('jdtls.dap').setup_dap_main_class_configs {
-    config_overrides = {
-      noDebug = true,
-    },
-  }
+  if dap.providers and dap.providers.configs then dap.providers.configs['jdtls'] = nil end
+
+  local jdtls_dap = require 'jdtls.dap'
+  -- Build separate entries for debugging and noDebug runs from the same discovered main classes.
+  jdtls_dap.fetch_main_configs({ config_overrides = { noDebug = false } }, function(configurations)
+    local dap_configurations = dap.configurations.java or {}
+
+    local function remove_main_class_configs(config)
+      for i = #dap_configurations, 1, -1 do
+        local existing_config = dap_configurations[i]
+        if
+          existing_config.type == 'java'
+          and existing_config.request == 'launch'
+          and existing_config.mainClass == config.mainClass
+          and existing_config.projectName == config.projectName
+          and existing_config.cwd == config.cwd
+        then
+          table.remove(dap_configurations, i)
+        end
+      end
+    end
+
+    local function append_config(config) table.insert(dap_configurations, config) end
+
+    for _, config in ipairs(configurations) do
+      remove_main_class_configs(config)
+
+      local debug_config = vim.deepcopy(config)
+      debug_config.name = debug_config.name:gsub('^Launch ', 'Debug ', 1)
+      debug_config.noDebug = false
+      append_config(debug_config)
+
+      local run_config = vim.deepcopy(config)
+      run_config.name = run_config.name:gsub('^Launch ', 'Run ', 1)
+      run_config.noDebug = true
+      append_config(run_config)
+    end
+
+    dap.configurations.java = dap_configurations
+  end)
 end
 
 jdtls.start_or_attach(config)

--- a/nvim/.config/nvim/lua/plugins/debugging.lua
+++ b/nvim/.config/nvim/lua/plugins/debugging.lua
@@ -69,6 +69,8 @@ return {
   },
   config = function(_, opts)
     local dap = require 'dap'
+    dap.defaults.fallback.terminal_win_cmd = 'botright 15new'
+    dap.defaults.fallback.focus_terminal = true
     require('dapui').setup(opts)
 
     -- Breakpoint signs
@@ -81,35 +83,38 @@ return {
     vim.fn.sign_define('DapLogPoint', { text = '', texthl = 'DiagnosticSignInfo', linehl = '', numhl = '' })
 
     -- Keymaps
-    vim.keymap.set('n', '<leader>bb', "<cmd>lua require'dap'.toggle_breakpoint()<cr>")
-    vim.keymap.set('n', '<leader>bc', "<cmd>lua require'dap'.set_breakpoint(vim.fn.input('Breakpoint condition: '))<cr>")
-    vim.keymap.set('n', '<leader>bl', "<cmd>lua require'dap'.set_breakpoint(nil, nil, vim.fn.input('Log point message: '))<cr>")
-    vim.keymap.set('n', '<leader>br', "<cmd>lua require'dap'.clear_breakpoints()<cr>")
-    vim.keymap.set('n', '<leader>ba', '<cmd>Telescope dap list_breakpoints<cr>')
-    vim.keymap.set('n', '<leader>dc', "<cmd>lua require'dap'.continue()<cr>")
-    vim.keymap.set('n', '<leader>dj', "<cmd>lua require'dap'.step_over()<cr>")
-    vim.keymap.set('n', '<leader>dk', "<cmd>lua require'dap'.step_into()<cr>")
-    vim.keymap.set('n', '<leader>do', "<cmd>lua require'dap'.step_out()<cr>")
+    vim.keymap.set('n', '<leader>bb', "<cmd>lua require'dap'.toggle_breakpoint()<cr>", { desc = 'Toggle Breakpoint' })
+    vim.keymap.set('n', '<leader>bc', "<cmd>lua require'dap'.set_breakpoint(vim.fn.input('Breakpoint condition: '))<cr>", { desc = 'Conditional Breakpoint' })
+    vim.keymap.set('n', '<leader>bl', "<cmd>lua require'dap'.set_breakpoint(nil, nil, vim.fn.input('Log point message: '))<cr>", { desc = 'Logpoint' })
+    vim.keymap.set('n', '<leader>br', "<cmd>lua require'dap'.clear_breakpoints()<cr>", { desc = 'Clear Breakpoints' })
+    vim.keymap.set('n', '<leader>ba', '<cmd>Telescope dap list_breakpoints<cr>', { desc = 'List Breakpoints' })
+    vim.keymap.set('n', '<leader>dc', "<cmd>lua require'dap'.continue()<cr>", { desc = 'Debug Continue' })
+    vim.keymap.set('n', '<leader>dj', "<cmd>lua require'dap'.step_over()<cr>", { desc = 'Debug Step Over' })
+    vim.keymap.set('n', '<leader>dk', "<cmd>lua require'dap'.step_into()<cr>", { desc = 'Debug Step Into' })
+    vim.keymap.set('n', '<leader>do', "<cmd>lua require'dap'.step_out()<cr>", { desc = 'Debug Step Out' })
     vim.keymap.set('n', '<leader>dd', function()
       require('dap').disconnect()
       require('dapui').close()
-    end)
+    end, { desc = 'Debug Disconnect' })
     vim.keymap.set('n', '<leader>dt', function()
       require('dap').terminate()
       require('dapui').close()
-    end)
-    vim.keymap.set('n', '<leader>dr', "<cmd>lua require'dap'.repl.toggle()<cr>")
-    vim.keymap.set('n', '<leader>dl', "<cmd>lua require'dap'.run_last()<cr>")
-    vim.keymap.set('n', '<leader>di', function() require('dap.ui.widgets').hover() end)
+    end, { desc = 'Debug Terminate' })
+    vim.keymap.set('n', '<leader>dr', "<cmd>lua require'dap'.repl.toggle()<cr>", { desc = 'Debug REPL' })
+    vim.keymap.set('n', '<leader>dl', "<cmd>lua require'dap'.run_last()<cr>", { desc = 'Debug Run Last' })
+    vim.keymap.set('n', '<leader>di', function() require('dap.ui.widgets').hover() end, { desc = 'Debug Inspect' })
     vim.keymap.set('n', '<leader>d?', function()
       local widgets = require 'dap.ui.widgets'
       widgets.centered_float(widgets.scopes)
-    end)
-    vim.keymap.set('n', '<leader>df', '<cmd>Telescope dap frames<cr>')
-    vim.keymap.set('n', '<leader>dh', '<cmd>Telescope dap commands<cr>')
-    vim.keymap.set('n', '<leader>de', function() require('telescope.builtin').diagnostics { default_text = ':E:' } end)
+    end, { desc = 'Debug Scopes' })
+    vim.keymap.set('n', '<leader>df', '<cmd>Telescope dap frames<cr>', { desc = 'Debug Frames' })
+    vim.keymap.set('n', '<leader>dh', '<cmd>Telescope dap commands<cr>', { desc = 'Debug Commands' })
+    vim.keymap.set('n', '<leader>de', function() require('telescope.builtin').diagnostics { default_text = ':E:' } end, { desc = 'Error Diagnostics' })
 
-    dap.listeners.after.event_initialized['dapui_config'] = function() require('dapui').open() end
+    dap.listeners.after.event_initialized['dapui_config'] = function(session)
+      if session.config.noDebug then return end
+      require('dapui').open()
+    end
     dap.listeners.before.event_terminated['dapui_config'] = function()
       -- Commented to prevent DAP UI from closing when unit tests finish
       -- require('dapui').close()

--- a/nvim/.config/nvim/lua/plugins/debugging.lua
+++ b/nvim/.config/nvim/lua/plugins/debugging.lua
@@ -69,18 +69,45 @@ return {
   },
   config = function(_, opts)
     local dap = require 'dap'
-    dap.defaults.fallback.terminal_win_cmd = 'botright 15new'
-    dap.defaults.fallback.focus_terminal = true
     require('dapui').setup(opts)
+    local dapui_terminal_win_cmd = dap.defaults.fallback.terminal_win_cmd
+    dap.defaults.fallback.terminal_win_cmd = function(config)
+      if config.type == 'java' and config.noDebug then
+        vim.cmd 'botright 15new'
+        return vim.api.nvim_get_current_buf(), vim.api.nvim_get_current_win()
+      end
+      return dapui_terminal_win_cmd(config)
+    end
+    dap.defaults.fallback.focus_terminal = true
+
+    local function prune_stopped_dap_terminals()
+      for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+        local name = vim.api.nvim_buf_get_name(bufnr)
+        if name:match '%[dap%-terminal%]' and vim.bo[bufnr].buftype == 'terminal' then
+          local job_id = vim.b[bufnr].terminal_job_id
+          local running = false
+          if job_id then
+            local ok, result = pcall(vim.fn.jobwait, { job_id }, 0)
+            running = ok and result[1] == -1
+          end
+          if not running then vim.api.nvim_buf_delete(bufnr, { force = true }) end
+        end
+      end
+    end
+
+    dap.listeners.on_config['dap_prune_stopped_terminals'] = function(config)
+      if config.type == 'java' and config.noDebug then prune_stopped_dap_terminals() end
+      return config
+    end
 
     -- Breakpoint signs
     vim.api.nvim_set_hl(0, 'DapStoppedHl', { fg = '#98BB6C', bg = '#2A2A2A', bold = true })
     vim.api.nvim_set_hl(0, 'DapStoppedLineHl', { bg = '#204028', bold = true })
-    vim.fn.sign_define('DapStopped', { text = '', texthl = 'DapStoppedHl', linehl = 'DapStoppedLineHl', numhl = '' })
-    vim.fn.sign_define('DapBreakpoint', { text = '', texthl = 'DiagnosticSignError', linehl = '', numhl = '' })
-    vim.fn.sign_define('DapBreakpointCondition', { text = '', texthl = 'DiagnosticSignWarn', linehl = '', numhl = '' })
-    vim.fn.sign_define('DapBreakpointRejected', { text = '', texthl = 'DiagnosticSignError', linehl = '', numhl = '' })
-    vim.fn.sign_define('DapLogPoint', { text = '', texthl = 'DiagnosticSignInfo', linehl = '', numhl = '' })
+    vim.fn.sign_define('DapStopped', { text = '>', texthl = 'DapStoppedHl', linehl = 'DapStoppedLineHl', numhl = '' })
+    vim.fn.sign_define('DapBreakpoint', { text = 'B', texthl = 'DiagnosticSignError', linehl = '', numhl = '' })
+    vim.fn.sign_define('DapBreakpointCondition', { text = 'C', texthl = 'DiagnosticSignWarn', linehl = '', numhl = '' })
+    vim.fn.sign_define('DapBreakpointRejected', { text = 'R', texthl = 'DiagnosticSignError', linehl = '', numhl = '' })
+    vim.fn.sign_define('DapLogPoint', { text = 'L', texthl = 'DiagnosticSignInfo', linehl = '', numhl = '' })
 
     -- Keymaps
     vim.keymap.set('n', '<leader>bb', "<cmd>lua require'dap'.toggle_breakpoint()<cr>", { desc = 'Toggle Breakpoint' })
@@ -92,6 +119,11 @@ return {
     vim.keymap.set('n', '<leader>dj', "<cmd>lua require'dap'.step_over()<cr>", { desc = 'Debug Step Over' })
     vim.keymap.set('n', '<leader>dk', "<cmd>lua require'dap'.step_into()<cr>", { desc = 'Debug Step Into' })
     vim.keymap.set('n', '<leader>do', "<cmd>lua require'dap'.step_out()<cr>", { desc = 'Debug Step Out' })
+    vim.keymap.set('n', '<F5>', "<cmd>lua require'dap'.step_into()<cr>", { desc = 'Debug Step Into' })
+    vim.keymap.set('n', '<F6>', "<cmd>lua require'dap'.step_over()<cr>", { desc = 'Debug Step Over' })
+    vim.keymap.set('n', '<F7>', "<cmd>lua require'dap'.step_out()<cr>", { desc = 'Debug Step Out' })
+    vim.keymap.set('n', '<F8>', "<cmd>lua require'dap'.continue()<cr>", { desc = 'Debug Continue' })
+    vim.keymap.set('n', '<F11>', "<cmd>lua require'dap'.run_last()<cr>", { desc = 'Debug Run Last' })
     vim.keymap.set('n', '<leader>dd', function()
       require('dap').disconnect()
       require('dapui').close()
@@ -112,7 +144,11 @@ return {
     vim.keymap.set('n', '<leader>de', function() require('telescope.builtin').diagnostics { default_text = ':E:' } end, { desc = 'Error Diagnostics' })
 
     dap.listeners.after.event_initialized['dapui_config'] = function(session)
-      if session.config.noDebug then return end
+      if session.config.noDebug then
+        require('dapui').close()
+        return
+      end
+      vim.cmd 'Neotree close'
       require('dapui').open()
     end
     dap.listeners.before.event_terminated['dapui_config'] = function()
@@ -124,21 +160,18 @@ return {
       -- require('dapui').close()
     end
 
-    -- Java debug configurations
-    dap.configurations.java = {
-      {
-        name = 'Debug Launch (2GB)',
-        type = 'java',
-        request = 'launch',
-        vmArgs = '' .. '-Xmx2g ',
-      },
-      {
-        name = 'Debug Attach (5005)',
-        type = 'java',
-        request = 'attach',
-        hostName = '127.0.0.1',
-        port = 5005,
-      },
-    }
+    -- Java attach configuration. Main-class launch configs are generated by ftplugin/java.lua.
+    local java_configurations = dap.configurations.java or {}
+    for i = #java_configurations, 1, -1 do
+      if java_configurations[i].name == 'Debug Attach (5005)' then table.remove(java_configurations, i) end
+    end
+    table.insert(java_configurations, {
+      name = 'Debug Attach (5005)',
+      type = 'java',
+      request = 'attach',
+      hostName = '127.0.0.1',
+      port = 5005,
+    })
+    dap.configurations.java = java_configurations
   end,
 }

--- a/nvim/.config/nvim/lua/plugins/lsp.lua
+++ b/nvim/.config/nvim/lua/plugins/lsp.lua
@@ -3,7 +3,7 @@ return {
     'neovim/nvim-lspconfig',
     dependencies = {
       { 'mason-org/mason.nvim', opts = {} },
-      { 'mason-org/mason-lspconfig.nvim', opts = {} },
+      { 'mason-org/mason-lspconfig.nvim', opts = { automatic_enable = { exclude = { 'jdtls' } } } },
       'WhoIsSethDaniel/mason-tool-installer.nvim',
       { 'j-hui/fidget.nvim', opts = {} },
       'saghen/blink.cmp',
@@ -83,7 +83,9 @@ return {
         on_init = function(client)
           if client.workspace_folders then
             local path = client.workspace_folders[1].name
-            if path ~= vim.fn.stdpath 'config' and (vim.uv.fs_stat(path .. '/.luarc.json') or vim.uv.fs_stat(path .. '/.luarc.jsonc')) then return end
+            if path ~= vim.fn.stdpath 'config' and (vim.fn.filereadable(path .. '/.luarc.json') == 1 or vim.fn.filereadable(path .. '/.luarc.jsonc') == 1) then
+              return
+            end
           end
           client.config.settings.Lua = vim.tbl_deep_extend('force', client.config.settings.Lua, {
             runtime = {

--- a/nvim/.config/nvim/lua/plugins/which-key.lua
+++ b/nvim/.config/nvim/lua/plugins/which-key.lua
@@ -8,6 +8,8 @@ return {
       { '<leader>s', group = '[S]earch', mode = { 'n', 'v' } },
       { '<leader>t', group = '[T]oggle' },
       { '<leader>h', group = 'Git [H]unk', mode = { 'n', 'v' } },
+      { '<leader>b', group = '[B]reakpoint' },
+      { '<leader>d', group = '[D]ebug' },
     },
   },
 }


### PR DESCRIPTION
## Summary
- Expose DAP and breakpoint keymaps in which-key.
- Keep Java JDTLS startup single-sourced by excluding jdtls from mason-lspconfig automatic enable.
- Configure Java DAP noDebug launch for verification and make DAP terminal open in a bottom split.
- Fix Java format setting typo and LuaLS diagnostics in the touched config.

Closes #17

## Verification
- Confirmed spring_tutorial app launch with DAP noDebug prints Hello World in [dap-terminal].
- Confirmed java-dap-check resolves dev.codex.check.App after adding Eclipse project metadata for the test project.
- stylua --check nvim/.config/nvim/ftplugin/java.lua nvim/.config/nvim/lua/plugins/lsp.lua nvim/.config/nvim/lua/plugins/debugging.lua nvim/.config/nvim/lua/plugins/which-key.lua
- git diff --check