### PR TITLE
[codex] Install dev tools with npm globals

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -14,9 +14,6 @@ brew "git"
 brew "gh"
 brew "lazygit"          # tmux <prefix>g
 
-# --- AI CLI（tmux ポップアップから呼ぶ）---
-brew "gemini-cli"       # tmux <prefix>G
-
 # --- nvim プラグインビルド依存 ---
 brew "make"
 brew "cmake"
@@ -33,7 +30,6 @@ brew "unzip"
 # --- Python ツール ---
 brew "uv"
 brew "ruff"
-brew "basedpyright"
 
 # --- 開発便利ツール ---
 brew "fzf"

--- a/setup-mac.sh
+++ b/setup-mac.sh
@@ -46,11 +46,20 @@ fi
 
 # グローバル npm パッケージ（追加はこの配列に行を増やす）
 NPM_GLOBALS=(
-  "obsidian-headless"  # Obsidian 自動化 CLI
+  "@google/gemini-cli"  # tmux <prefix>G
+  "basedpyright"        # Python LSP / type checker
+  "obsidian-headless"   # Obsidian 自動化 CLI
 )
 if command -v npm &>/dev/null && [[ ${#NPM_GLOBALS[@]} -gt 0 ]]; then
   echo "Installing global npm packages..."
   npm install -g "${NPM_GLOBALS[@]}"
+  _npm_global_root="$(npm root -g)"
+  _better_sqlite3_dir="$_npm_global_root/obsidian-headless/node_modules/better-sqlite3"
+  if [[ -d "$_better_sqlite3_dir" ]]; then
+    echo "Rebuilding obsidian-headless native dependencies..."
+    (cd "$_better_sqlite3_dir" && npm rebuild --ignore-scripts=false)
+  fi
+  unset _npm_global_root _better_sqlite3_dir
 fi
 
 # Codex CLI は remote-control/app-server daemon が standalone layout を前提にするため、


### PR DESCRIPTION
## Summary

- remove `gemini-cli` and `basedpyright` from `Brewfile`
- install `@google/gemini-cli`, `basedpyright`, and `obsidian-headless` through the npm global package step
- rebuild `obsidian-headless`'s `better-sqlite3` dependency when it exists

Closes #22

## Why

These tools are better managed through the npm global toolchain used by `setup-mac.sh`, and `obsidian-headless` can require its native `better-sqlite3` dependency to be rebuilt after installation.

## Validation

- `bash -n setup-mac.sh`
