### PR TITLE
[codex] Add lazysql terminal SQL client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .claude/
 __pycache__/
+lazysql/.config/lazysql/config.toml

--- a/Brewfile
+++ b/Brewfile
@@ -34,6 +34,7 @@ brew "ruff"
 # --- 開発便利ツール ---
 brew "fzf"
 brew "jq"
+brew "lazysql"          # tmux <prefix>q
 brew "tree"
 brew "shellcheck"       # Claude Code の自動フォーマットフックが使用
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ brew bundle
 | nvim | `~/.config/nvim/` |
 | tmux | `~/.tmux.conf` |
 | bin | `~/.local/bin/` |
+| lazysql | `~/.config/lazysql/` |
 
 ### Brewfile へのパッケージ追加
 
@@ -48,6 +49,30 @@ brew bundle
 echo 'brew "ripgrep"' >> Brewfile
 brew bundle
 ```
+
+## ターミナル内SQLクライアント
+
+`lazysql` は MySQL / PostgreSQL / SQLite / MSSQL に対応したTUIデータベースクライアントです。
+tmux では `Prefix + q` でセッション維持型ポップアップとして起動します。
+
+接続設定は `~/.config/lazysql/config.toml` に保存されます。このリポジトリでは
+`lazysql/.config/lazysql/config.toml.example` だけを管理し、実際の `config.toml` は `.gitignore` で除外します。
+
+```bash
+cp ~/.config/lazysql/config.toml.example ~/.config/lazysql/config.toml
+$EDITOR ~/.config/lazysql/config.toml
+```
+
+パスワードなどの秘密情報は、`config.toml` に直書きせず `${env:VAR_NAME}` 形式で環境変数から参照してください。
+
+基本操作:
+- `n`: 接続を追加
+- `c` / `Enter`: 接続
+- `j` / `k`: 移動
+- `[` / `]`: テーブル表示タブの切り替え
+- `Ctrl+E`: SQLエディタを開く
+- `Ctrl+R`: SQLを実行
+- `?`: ヘルプ
 
 ## エージェント利用率の表示
 

--- a/install.sh
+++ b/install.sh
@@ -8,5 +8,6 @@ stow --target="$HOME" zsh
 stow --target="$HOME" nvim
 stow --target="$HOME" tmux
 stow --target="$HOME" bin
+stow --target="$HOME" lazysql
 
 echo "Done!"

--- a/lazysql/.config/lazysql/config.toml.example
+++ b/lazysql/.config/lazysql/config.toml.example
@@ -1,0 +1,38 @@
+# Example lazysql configuration.
+# Copy this file to config.toml and edit it locally:
+#
+#   cp ~/.config/lazysql/config.toml.example ~/.config/lazysql/config.toml
+#
+# The real config.toml is intentionally ignored by git because it may contain
+# database hosts, usernames, and passwords.
+
+[application]
+DefaultPageSize = 300
+DisableSidebar = false
+SidebarOverlay = false
+JSONViewerWordWrap = false
+EnterOpensJSONViewer = false
+
+# SQLite example
+#
+# [[database]]
+# Name = 'local-sqlite'
+# Provider = 'sqlite'
+# URL = 'file:/tmp/example.sqlite3?loc=auto'
+# ReadOnly = true
+
+# PostgreSQL example. Prefer environment variables for secrets.
+#
+# [[database]]
+# Name = 'local-postgres'
+# Provider = 'postgres'
+# URL = 'postgres://${env:DB_USER}:${env:DB_PASSWORD}@localhost:5432/app'
+# ReadOnly = true
+
+# MySQL example
+#
+# [[database]]
+# Name = 'local-mysql'
+# Provider = 'mysql'
+# URL = 'mysql://${env:DB_USER}:${env:DB_PASSWORD}@localhost:3306/app'
+# ReadOnly = true

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -103,3 +103,4 @@ POPUP_WITH_SESSION=' \
 bind -r a run-shell "POPUP_NAME=claude POPUP_CMD=claude $POPUP_WITH_SESSION"
 bind -r o run-shell "POPUP_NAME=codex  POPUP_CMD=codex  $POPUP_WITH_SESSION"
 bind -r G run-shell "POPUP_NAME=gemini POPUP_CMD=gemini $POPUP_WITH_SESSION"
+bind -r q run-shell "POPUP_NAME=lazysql POPUP_CMD=lazysql $POPUP_WITH_SESSION"


### PR DESCRIPTION
## Summary
- add lazysql to the Homebrew bundle
- manage lazysql config through stow with a committed example template
- ignore the real lazysql config file so database credentials are not committed
- add a tmux Prefix + q popup binding and README usage notes

Closes #27

## Validation
- git diff --check
- parsed lazysql/.config/lazysql/config.toml.example with Python tomllib
- stow --target="/Users/nakamurashouta" --no --verbose lazysql
- tmux config loaded with a temporary tmux server
- brew info lazysql confirmed local formula metadata; additional Homebrew API lookup failed due DNS resolution for formulae.brew.sh
