### PR TITLE
fix: tmux内のSSH判定をtmux show-environmentにフォールバック

### DIFF
--- a/bin/.local/bin/clip
+++ b/bin/.local/bin/clip
@@ -11,6 +11,15 @@ else
   cat >"$tmp"
 fi
 
+# tmux内でSSH変数が未設定の場合、tmuxのグローバル環境から取得する。
+if [ -n "${TMUX:-}" ] && [ -z "${SSH_CONNECTION:-}" ] && command -v tmux >/dev/null 2>&1; then
+  _val="$(tmux show-environment SSH_CONNECTION 2>/dev/null)" || true
+  case "$_val" in SSH_CONNECTION=*) export SSH_CONNECTION="${_val#SSH_CONNECTION=}" ;; esac
+  _val="$(tmux show-environment SSH_TTY 2>/dev/null)" || true
+  case "$_val" in SSH_TTY=*) export SSH_TTY="${_val#SSH_TTY=}" ;; esac
+  unset _val
+fi
+
 # ローカルのmacOS上では通常のpbcopyを使う。
 if [ -z "${SSH_CONNECTION:-}${SSH_TTY:-}" ] && command -v pbcopy >/dev/null 2>&1; then
   pbcopy <"$tmp"

--- a/bin/.local/bin/clip
+++ b/bin/.local/bin/clip
@@ -11,17 +11,8 @@ else
   cat >"$tmp"
 fi
 
-# tmux内でSSH変数が未設定の場合、tmuxのグローバル環境から取得する。
-if [ -n "${TMUX:-}" ] && [ -z "${SSH_CONNECTION:-}" ] && command -v tmux >/dev/null 2>&1; then
-  _val="$(tmux show-environment SSH_CONNECTION 2>/dev/null)" || true
-  case "$_val" in SSH_CONNECTION=*) export SSH_CONNECTION="${_val#SSH_CONNECTION=}" ;; esac
-  _val="$(tmux show-environment SSH_TTY 2>/dev/null)" || true
-  case "$_val" in SSH_TTY=*) export SSH_TTY="${_val#SSH_TTY=}" ;; esac
-  unset _val
-fi
-
 # ローカルのmacOS上では通常のpbcopyを使う。
-if [ -z "${SSH_CONNECTION:-}${SSH_TTY:-}" ] && command -v pbcopy >/dev/null 2>&1; then
+if ! is-ssh && command -v pbcopy >/dev/null 2>&1; then
   pbcopy <"$tmp"
   exit 0
 fi
@@ -34,18 +25,19 @@ tmux_passthrough=0
 # 実SSH端末のTTYがtmux clientとして存在するならそちらを優先する。
 if [ -n "${TMUX:-}" ] && command -v tmux >/dev/null 2>&1; then
   client_tty="$(tmux display-message -p '#{client_tty}' 2>/dev/null || true)"
+  ssh_tty="$(is-ssh --tty 2>/dev/null)" || true
   ssh_tty_attached=0
-  if [ -n "${SSH_TTY:-}" ] && [ -w "$SSH_TTY" ]; then
+  if [ -n "$ssh_tty" ] && [ -w "$ssh_tty" ]; then
     for tty in $(tmux list-clients -F '#{client_tty}' 2>/dev/null || true); do
-      if [ "$tty" = "$SSH_TTY" ]; then
+      if [ "$tty" = "$ssh_tty" ]; then
         ssh_tty_attached=1
         break
       fi
     done
   fi
 
-  if [ "$ssh_tty_attached" -eq 1 ] && [ "$client_tty" != "$SSH_TTY" ]; then
-    output="$SSH_TTY"
+  if [ "$ssh_tty_attached" -eq 1 ] && [ "$client_tty" != "$ssh_tty" ]; then
+    output="$ssh_tty"
   elif [ -n "$client_tty" ] && [ -w "$client_tty" ]; then
     output="$client_tty"
   else

--- a/bin/.local/bin/is-ssh
+++ b/bin/.local/bin/is-ssh
@@ -1,0 +1,25 @@
+#!/bin/sh
+#   引数なし: SSH経由なら終了コード0、それ以外は1
+#   --tty:    SSH_TTYの値を標準出力に出力（見つからなければ何も出力せず終了コード1）
+set -eu
+
+_tmux_getenv() {
+  [ -n "${TMUX:-}" ] && command -v tmux >/dev/null 2>&1 || return 1
+  val="$(tmux show-environment "$1" 2>/dev/null)" || return 1
+  case "$val" in "$1"=*) echo "${val#*=}"; return 0 ;; esac
+  return 1
+}
+
+case "${1:-}" in
+  --tty)
+    if [ -n "${SSH_TTY:-}" ]; then echo "$SSH_TTY"; exit 0; fi
+    _tmux_getenv SSH_TTY && exit 0
+    exit 1
+    ;;
+  *)
+    [ -n "${SSH_CONNECTION:-}${SSH_TTY:-}" ] && exit 0
+    _tmux_getenv SSH_CONNECTION >/dev/null && exit 0
+    _tmux_getenv SSH_TTY >/dev/null && exit 0
+    exit 1
+    ;;
+esac

--- a/nvim/.config/nvim/lua/config/options.lua
+++ b/nvim/.config/nvim/lua/config/options.lua
@@ -7,7 +7,15 @@ vim.o.mouse = 'a'
 vim.o.showmode = false
 
 -- Sync clipboard between OS and Neovim.
-local use_ssh_clipboard = (vim.env.SSH_CONNECTION or vim.env.SSH_TTY) and vim.fn.executable('clip') == 1
+local function tmux_getenv(name)
+  if not vim.env.TMUX then return nil end
+  local out = vim.fn.system({ 'tmux', 'show-environment', name })
+  return out:match('^' .. name .. '=([^\n]*)')
+end
+
+local ssh_connection = vim.env.SSH_CONNECTION or tmux_getenv('SSH_CONNECTION')
+local ssh_tty = vim.env.SSH_TTY or tmux_getenv('SSH_TTY')
+local use_ssh_clipboard = (ssh_connection or ssh_tty) and vim.fn.executable('clip') == 1
 if use_ssh_clipboard then
   vim.g.ssh_clipboard_copy = true
   vim.g.clipboard = {

--- a/nvim/.config/nvim/lua/config/options.lua
+++ b/nvim/.config/nvim/lua/config/options.lua
@@ -7,15 +7,9 @@ vim.o.mouse = 'a'
 vim.o.showmode = false
 
 -- Sync clipboard between OS and Neovim.
-local function tmux_getenv(name)
-  if not vim.env.TMUX then return nil end
-  local out = vim.fn.system({ 'tmux', 'show-environment', name })
-  return out:match('^' .. name .. '=([^\n]*)')
-end
-
-local ssh_connection = vim.env.SSH_CONNECTION or tmux_getenv('SSH_CONNECTION')
-local ssh_tty = vim.env.SSH_TTY or tmux_getenv('SSH_TTY')
-local use_ssh_clipboard = (ssh_connection or ssh_tty) and vim.fn.executable('clip') == 1
+local use_ssh_clipboard = vim.fn.executable('is-ssh') == 1
+  and os.execute('is-ssh') == 0
+  and vim.fn.executable('clip') == 1
 if use_ssh_clipboard then
   vim.g.ssh_clipboard_copy = true
   vim.g.clipboard = {

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -37,6 +37,9 @@ set -g set-clipboard on
 set -g allow-passthrough on
 set -as terminal-features ',xterm*:clipboard'
 
+# tmux attach時にSSH_TTYをセッション環境へ反映させる（デフォルトリストにはSSH_CONNECTIONのみ）。
+set -ag update-environment 'SSH_TTY'
+
 # --- ペイン操作 (Vimライク) ---
 # 直感的なキーでペインを分割する (-c "#{pane_current_path}" で現在のディレクトリを引き継ぐ)
 bind | split-window -h -c "#{pane_current_path}" # 縦に分割


### PR DESCRIPTION
## Summary
- `clip` と Neovim の SSH 判定で、プロセス環境変数が空の場合に `tmux show-environment` からフォールバック取得するよう修正
- `.tmux.conf` に `SSH_TTY` を `update-environment` に追加し、attach 後の新ペインにも伝播させる
- ローカル起動 tmux に SSH で attach した際、既存ペインでも OSC 52 クリップボード連携が機能するようになる

Closes #33

## Test plan
- [x] ローカルのみで tmux 起動 → `clip` が `pbcopy` を使うことを確認（回帰テスト）
- [x] SSH → tmux 起動 → `clip` が OSC 52 を使うことを確認（回帰テスト）
- [x] ローカルで tmux 起動 → SSH で attach → 既存ペインで `clip` が OSC 52 を使うことを確認
- [x] SSH attach 後に新ペイン作成 → `echo $SSH_TTY` で値が設定されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)