### PR TITLE
AIエージェント(Claude/Codex)のターン完了をデスクトップ通知する

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -40,6 +40,7 @@ brew "tree"
 brew "shellcheck"       # Claude Code の自動フォーマットフックが使用
 
 # --- macOS 専用（cask は Homebrew 上で macOS 限定。Linux では別途 apt 等で導入する） ---
+brew "terminal-notifier"              # AIエージェントのターン完了デスクトップ通知（agent-notify）
 cask "docker-desktop"                 # tmux でアプリ完結（旧 cask "docker" は非推奨）
 cask "claude-code"                    # tmux <prefix>a
 cask "font-jetbrains-mono-nerd-font"  # 接続元ターミナルのフォント（Ubuntu Server へも反映）

--- a/README.md
+++ b/README.md
@@ -114,6 +114,56 @@ tmux では `Prefix + u` でポップアップ表示できます（`r` で再取
 `enabled: false` にしたエージェントは取得処理自体が実行されません。
 新しいエージェントの追加手順はスクリプト先頭の docstring を参照してください。
 
+## AIエージェントのターン完了通知
+
+`agent-notify` は Claude Code / Codex のターン完了・承認待ちを `terminal-notifier` でデスクトップ通知します。
+複数セッションを並行で動かしてもプロジェクト名で見分けられ、通知をクリックすると該当の tmux ペインへ復帰します。
+
+- タイトルに `<agent> ▸ <cwd の basename>`、サブタイトルに状態（ターン完了 / 承認待ち / 入力待ち）、本文に発話プレビュー
+- `-group "<agent>-<TMUX_PANE>"` で連続通知を最新 1 件に集約
+- クリック時は terminal-notifier の `-activate` で iTerm を前面化し、`-execute` で `agent-focus-pane` を呼んで該当ペインへ復帰
+
+クリック復帰（`agent-focus-pane`）はペインの所属セッションで挙動を分けます。
+
+- 通常のウィンドウ/ペイン: `switch-client` / `select-window` / `select-pane` で移動
+- セッション維持型ポップアップ（`prefix + a` 等で起動した `<agent>-<hash>` セッション）: メインクライアントを直接アタッチさせると（`switch-client`）デタッチ時に tmux を抜けてしまうため行わず、ポップアップが閉じていればメインクライアント上で `display-popup` を開き直す。デタッチすると元のセッションへ戻る
+
+前提として `terminal-notifier`（Brewfile に記載）が必要です。未導入時や tmux 外では iTerm の前面化のみにフォールバックします。
+
+### Claude Code
+
+`~/.claude/settings.json` の `hooks` で Stop / Notification から呼びます。
+
+```json
+{
+  "hooks": {
+    "Stop": [
+      { "matcher": "", "hooks": [
+        { "type": "command", "command": "/Users/<user>/.local/bin/agent-notify claude-stop" }
+      ] }
+    ],
+    "Notification": [
+      { "matcher": "", "hooks": [
+        { "type": "command", "command": "/Users/<user>/.local/bin/agent-notify claude-notification" }
+      ] }
+    ]
+  }
+}
+```
+
+### Codex
+
+`~/.codex/config.toml` の `notify` で呼びます（Codex は JSON を末尾の引数として渡します）。
+
+```toml
+notify = ["/Users/<user>/.local/bin/agent-notify", "codex"]
+```
+
+`notify` はプログラムを 1 つしか指定できないため、他の notify 連携（Computer Use 等）とは併用できません。
+
+> **SSH 接続時は未対応**: リモート側に GUI が無いため、`agent-notify` は SSH 検出時（`is-ssh`）に何もしません。
+> リモートからローカル macOS へ通知を届ける経路は今後の検討事項です。
+
 ## SSH元クリップボードへのコピー
 
 SSH接続中は `clip` コマンドがOSC 52を使ってSSHクライアント側のクリップボードへコピーします。

--- a/bin/.local/bin/agent-focus-pane
+++ b/bin/.local/bin/agent-focus-pane
@@ -1,0 +1,87 @@
+#!/bin/sh
+# terminal-notifier の -execute から呼ばれ、通知クリックで該当 tmux ペインへ復帰する。
+#   引数: TMUX_PANE（例: %52）
+# terminal-notifier の GUI 実行コンテキストは PATH を継承しないため tmux はフルパス指定する。
+set -eu
+
+PANE="${1:-}"
+[ -n "$PANE" ] || exit 0
+
+TMUX_BIN=/opt/homebrew/bin/tmux
+[ -x "$TMUX_BIN" ] || TMUX_BIN="$(command -v tmux 2>/dev/null || true)"
+
+# ポップアップ起動セッション（<agent>-<8桁hex> 命名）かどうかを判定する。
+# このリポジトリの tmux ポップアップ（prefix+a 等）は <name>-md5sum8 のセッションで動く。
+is_popup_session() {
+  case "$1" in
+    claude-*|codex-*|gemini-*|lazysql-*|lazydocker-*)
+      case "${1##*-}" in
+        [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]) return 0 ;;
+      esac
+      ;;
+  esac
+  return 1
+}
+
+# ポップアップ以外（ユーザーのメイン）クライアントを 1 つ返す。
+find_main_client() {
+  for c in $("$TMUX_BIN" list-clients -F '#{client_name}::#{client_session}' 2>/dev/null); do
+    if ! is_popup_session "${c##*::}"; then
+      printf '%s' "${c%%::*}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# 指定セッションにアタッチ中のクライアントが居るか。
+session_has_client() {
+  [ -n "$("$TMUX_BIN" list-clients -t "$1" -F '#{client_name}' 2>/dev/null)" ]
+}
+
+# iTerm を先に前面化する。osascript の activate は背景プロセス（terminal-notifier の
+# -execute 経由）からだと macOS のフォーカス奪取抑止で前面化せず（exit 0 でも無効）、
+# LaunchServices 経由の open -a なら確実に前面化する。
+# また display-popup はポップアップが閉じるまでブロックすることがあるため、tmux 操作
+# より前に前面化しておく（末尾に置くとポップアップ再オープン時に実行されない）。
+# terminal-notifier は -execute と -activate を併用すると -execute のみ実行するため、
+# 前面化はこの -execute 側で行う必要がある。
+open -a iTerm 2>/dev/null || true
+
+if [ -n "$TMUX_BIN" ]; then
+  info="$("$TMUX_BIN" display-message -p -t "$PANE" '#{session_name}|#{window_id}|#{pane_id}' 2>/dev/null || true)"
+  session="${info%%|*}"
+  rest="${info#*|}"
+  window="${rest%%|*}"
+  pane_id="${rest##*|}"
+
+  if [ -z "$session" ]; then
+    : # ペインが既に無い等で解決できない場合は前面化のみ。
+  elif is_popup_session "$session"; then
+    # ポップアップセッションは display-popup 経由で表示する設計。
+    # switch-client でメインクライアントを直接アタッチさせると、デタッチ時に
+    # 元セッションへ戻れず tmux を抜けてしまうため行わない。
+    if ! session_has_client "$session"; then
+      # ポップアップが閉じている → メインクライアント上で開き直す。
+      main_client="$(find_main_client || true)"
+      if [ -n "$main_client" ]; then
+        "$TMUX_BIN" display-popup -c "$main_client" -w90% -h90% \
+          -E "$TMUX_BIN attach-session -t \"$session\"" 2>/dev/null || true
+      fi
+    fi
+  else
+    # 通常のウィンドウ/ペイン。まずセッション内のウィンドウ・ペインを選択する
+    # （対象セッションを表示中のクライアントは自動的に追従する）。
+    "$TMUX_BIN" select-window -t "$window" 2>/dev/null || true
+    "$TMUX_BIN" select-pane  -t "$pane_id" 2>/dev/null || true
+    # 対象セッションを表示中のクライアントが無い場合のみ、メインクライアントを切り替える。
+    # -c を付けず switch-client すると暗黙の「現在のクライアント」（ポップアップ等）を
+    # 誤って掴み、別クライアントのウィンドウフォーカスを乱すため -c を明示する。
+    if ! session_has_client "$session"; then
+      main_client="$(find_main_client || true)"
+      if [ -n "$main_client" ]; then
+        "$TMUX_BIN" switch-client -c "$main_client" -t "$session" 2>/dev/null || true
+      fi
+    fi
+  fi
+fi

--- a/bin/.local/bin/agent-notify
+++ b/bin/.local/bin/agent-notify
@@ -1,0 +1,125 @@
+#!/bin/sh
+# AI エージェント（Claude/Codex）のターン完了・承認待ちをデスクトップ通知する。
+# terminal-notifier で通知し、クリックで tmux の該当ペインへ復帰する（agent-focus-pane）。
+#
+# 使い方:
+#   agent-notify claude-stop          # Claude Code Stop フック（stdin に JSON）
+#   agent-notify claude-notification  # Claude Code Notification フック（stdin に JSON）
+#   agent-notify codex '<json>'       # Codex notify（argv に JSON）
+#
+# title    = "<agent> ▸ <cwd の basename>"
+# subtitle = 状態（ターン完了 / 承認待ち / 入力待ち）
+# message  = 本文プレビュー
+# group    = "<agent>-<TMUX_PANE>" で連続通知を最新 1 件に集約
+set -eu
+
+SELF_DIR="$(unset CDPATH; cd "$(dirname "$0")" && pwd)"
+
+TMUX_BIN=/opt/homebrew/bin/tmux
+[ -x "$TMUX_BIN" ] || TMUX_BIN="$(command -v tmux 2>/dev/null || true)"
+
+# Neovim の :terminal 等で TMUX_PANE が継承されない場合に、自プロセスの親を辿って
+# tmux の pane_pid と一致するペインを特定する。tmux 外なら見つからず失敗する。
+resolve_pane_via_pid() {
+  [ -n "$TMUX_BIN" ] || return 1
+  _panes="$("$TMUX_BIN" list-panes -a -F '#{pane_pid} #{pane_id}' 2>/dev/null)" || return 1
+  [ -n "$_panes" ] || return 1
+  _pid=$$
+  _i=0
+  while [ "${_pid:-0}" -gt 1 ] && [ "$_i" -lt 30 ]; do
+    _m="$(printf '%s\n' "$_panes" | awk -v p="$_pid" '$1==p{print $2; exit}')"
+    if [ -n "$_m" ]; then printf '%s' "$_m"; return 0; fi
+    _pid="$(ps -o ppid= -p "$_pid" 2>/dev/null | tr -d ' ')"
+    _i=$((_i + 1))
+  done
+  return 1
+}
+
+# --- SSH 経由ではローカル GUI が無いため通知しない（issue #35: SSH 経路は未対応） ---
+if [ -x "$SELF_DIR/is-ssh" ] && "$SELF_DIR/is-ssh" 2>/dev/null; then
+  exit 0
+fi
+
+mode="${1:-}"
+agent=
+state=
+message=
+cwd=
+
+case "$mode" in
+  claude-stop)
+    agent=claude
+    state="ターン完了"
+    payload="$(cat)"
+    cwd="$(printf '%s' "$payload" | jq -r '.cwd // empty' 2>/dev/null || true)"
+    transcript="$(printf '%s' "$payload" | jq -r '.transcript_path // empty' 2>/dev/null || true)"
+    # 直近のアシスタント発話をプレビューに使う（best-effort）。
+    if [ -n "$transcript" ] && [ -f "$transcript" ]; then
+      message="$(tail -n 50 "$transcript" 2>/dev/null | jq -rs '
+        [ .[]
+          | select(.type == "assistant")
+          | .message.content[]?
+          | select(.type == "text")
+          | .text
+        ] | last // empty
+      ' 2>/dev/null || true)"
+    fi
+    ;;
+  claude-notification)
+    agent=claude
+    payload="$(cat)"
+    cwd="$(printf '%s' "$payload" | jq -r '.cwd // empty' 2>/dev/null || true)"
+    message="$(printf '%s' "$payload" | jq -r '.message // empty' 2>/dev/null || true)"
+    # メッセージ内容から種別を推定する。
+    case "$message" in
+      *permission*|*approve*|*承認*) state="承認待ち" ;;
+      *) state="入力待ち" ;;
+    esac
+    ;;
+  codex)
+    agent=codex
+    state="ターン完了"
+    payload="${2:-}"
+    message="$(printf '%s' "$payload" | jq -r '.["last-assistant-message"] // empty' 2>/dev/null || true)"
+    cwd="$PWD"
+    ;;
+  *)
+    printf 'agent-notify: unknown mode: %s\n' "$mode" >&2
+    exit 2
+    ;;
+esac
+
+[ -n "$cwd" ] || cwd="$PWD"
+project="$(basename "$cwd")"
+[ -n "$message" ] || message="$state"
+
+# プレビューは改行を除き長すぎると見づらいため切り詰める。
+message="$(printf '%s' "$message" | tr '\n' ' ' | cut -c1-140)"
+
+# TMUX_PANE が環境に無い（Neovim の :terminal 等）場合は親プロセスから特定する。
+pane="${TMUX_PANE:-}"
+[ -n "$pane" ] || pane="$(resolve_pane_via_pid || true)"
+title="$agent ▸ $project"
+group="$agent-${pane:-nopane}"
+
+NOTIFIER="$(command -v terminal-notifier 2>/dev/null || true)"
+
+# terminal-notifier 未導入時のフォールバック: iTerm を前面化するのみ。
+if [ -z "$NOTIFIER" ]; then
+  open -a iTerm 2>/dev/null || true
+  exit 0
+fi
+
+set -- -title "$title" -subtitle "$state" -message "$message" -group "$group" -sound Glass
+
+# tmux 内ならクリックで該当ペインへ復帰、tmux 外なら iTerm 前面化のみ。
+# 注: terminal-notifier は -execute と -activate を併用すると -execute のみ実行する。
+#     そのため tmux 内では -execute（agent-focus-pane）側で open -a により前面化し、
+#     tmux 外（-execute なし）では -activate で前面化する。
+if [ -n "$pane" ]; then
+  set -- "$@" -execute "/bin/sh $SELF_DIR/agent-focus-pane $pane"
+else
+  set -- "$@" -activate com.googlecode.iterm2
+fi
+
+"$NOTIFIER" "$@"


### PR DESCRIPTION
## 概要

agent-tts の音声読み上げを `terminal-notifier` によるデスクトップ通知へ置き換える（issue #35）。
Claude Code / Codex のターン完了・承認待ちを通知し、クリックで該当 tmux ペインへ復帰する。

## 変更

- **`bin/.local/bin/agent-notify`**（新規）: 通知送信本体。`claude-stop` / `claude-notification` / `codex` の3モード。
  - title=`<agent> ▸ <cwd basename>`、subtitle=状態（ターン完了/承認待ち/入力待ち）、message=発話プレビュー
  - `-group "<agent>-<TMUX_PANE>"` で連続通知を最新1件に集約
  - SSH 検出時（`is-ssh`）と `terminal-notifier` 未導入時はフォールバック
- **`bin/.local/bin/agent-focus-pane`**（新規）: クリック復帰。
  - 通常ペインは `switch-client` / `select-window` / `select-pane`
  - セッション維持型ポップアップ（`<agent>-<hash>`）はメインクライアントを直接アタッチさせず `display-popup` で開き直す（デタッチで tmux を抜けない）
  - `-activate` と併せて iTerm を前面化
- **`Brewfile`**: `terminal-notifier` を追加
- **`README.md`**: 通知セクションを追加

## 実機側の設定（このリポジトリ外・別途反映）

- `~/.claude/settings.json` の Stop / Notification で `agent-notify` を呼ぶ
- `~/.codex/config.toml` の `notify` を `agent-notify` に一本化

## 検証

- 3モードの通知発火、プレビュー抽出、状態判定、group 集約を確認
- 通常ペイン復帰、ポップアップ再オープン（デタッチで `main` に戻る）、iTerm 前面化を実機で確認
- `shellcheck` OK

## 据え置き（issue に残す）

- SSH 経路（リモートからローカル macOS への通知）

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)