### PR TITLE
[codex] prevent notifier failures from failing agent hooks

### DIFF
--- a/bin/.local/bin/agent-notify
+++ b/bin/.local/bin/agent-notify
@@ -195,5 +195,8 @@ else
   set -- "$@" -activate com.googlecode.iterm2
 fi
 
-"$NOTIFIER" "$@"
+# 通知プロセスの異常終了で Codex / Claude のフック自体を失敗させない。
+if ! "$NOTIFIER" "$@"; then
+  printf 'agent-notify: terminal-notifier failed\n' >&2
+fi
 finish 0


### PR DESCRIPTION
## What changed

- Treat `terminal-notifier` failures as non-fatal in `agent-notify`
- Keep the existing `terminal-notifier` integration, notification grouping, and tmux pane activation
- Preserve the Codex command-hook response on stdout

## Why

`agent-notify` runs with `set -e`. When `terminal-notifier` exits abnormally, that failure previously propagated from the script and caused Codex to report `Stop hook failed`, even though desktop notification is a best-effort side effect.

The notifier failure is now reported on stderr while the hook completes normally.

## Impact

Codex and Claude hooks no longer fail solely because desktop notification failed. Existing notification behavior is unchanged when `terminal-notifier` succeeds.

## Validation

- `sh -n bin/.local/bin/agent-notify`
- `git diff --check`
- Executed `agent-notify codex-stop` while `terminal-notifier` aborted:
  - exit code: `0`
  - stdout: `{}`
  - failure recorded on stderr

Closes #40
