### PR TITLE
ポップアップ判定を命名規則から明示マーカー(@popup)へ置き換える

### DIFF
--- a/bin/.local/bin/agent-focus-pane
+++ b/bin/.local/bin/agent-focus-pane
@@ -10,17 +10,10 @@ PANE="${1:-}"
 TMUX_BIN=/opt/homebrew/bin/tmux
 [ -x "$TMUX_BIN" ] || TMUX_BIN="$(command -v tmux 2>/dev/null || true)"
 
-# ポップアップ起動セッション（<agent>-<8桁hex> 命名）かどうかを判定する。
-# このリポジトリの tmux ポップアップ（prefix+a 等）は <name>-md5sum8 のセッションで動く。
+# ポップアップ起動セッション（@popup マーカー付き）かどうかを判定する。
+# このリポジトリの tmux ポップアップ（prefix+a 等）は生成時に @popup=1 を設定する。
 is_popup_session() {
-  case "$1" in
-    claude-*|codex-*|gemini-*|lazysql-*|lazydocker-*)
-      case "${1##*-}" in
-        [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]) return 0 ;;
-      esac
-      ;;
-  esac
-  return 1
+  [ "$("$TMUX_BIN" show-options -t "$1" -qv @popup)" = 1 ]
 }
 
 # ポップアップ以外（ユーザーのメイン）クライアントを 1 つ返す。

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -99,6 +99,7 @@ POPUP_WITH_SESSION=' \
       -x "$POPUP_W" -y "$POPUP_H" \
       "$POPUP_CMD"; \
     tmux set-option -t "$SESSION" window-size latest; \
+    tmux set-option -t "$SESSION" @popup 1; \
   fi; \
   tmux display-popup -w90% -h90% -E "tmux attach-session -t $SESSION"'
 


### PR DESCRIPTION
## 概要

issue #38 の対応。ポップアップ起動セッションの判定を、セッション名の命名規則 `<agent>-<8桁hex>` から tmux ユーザーオプション `@popup` による明示マーカーへ置き換える。

## 背景

`bin/.local/bin/agent-focus-pane` の `is_popup_session` は命名規則でポップアップ判定していたが、以下の弱点があった。

- エージェント名をハードコード（`claude-/codex-/gemini-/lazysql-/lazydocker-`）しており、新規ポップアップ対象の追加時に `.tmux.conf` と `agent-focus-pane` の両方を修正する必要がある
- 偶然 `foo-1234abcd` のような通常セッションを誤検出し得る
- `.tmux.conf` の命名規則と `agent-focus-pane` の判定が暗黙に結合している

## 変更内容

- `tmux/.tmux.conf`: ポップアップセッション生成時（`new-session` 直後）に `tmux set-option -t "$SESSION" @popup 1` を付与
- `bin/.local/bin/agent-focus-pane`: `is_popup_session` を `@popup` オプション判定へ置き換え、エージェント名のハードコードを削除

## 検証

設定反映後に作り直したポップアップセッションで動作確認済み。

- `@popup=1` のポップアップセッションのみ POPUP 判定
- マーカーが無い通常セッション（`<agent>-<hex>` 形でも）は誤検出せず normal 判定

| セッション | @popup | 判定 |
|---|---|---|
| codex（反映後に作成） | 1 | POPUP |
| codex（旧セッション） | 空 | normal |
| main | 空 | normal |

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)